### PR TITLE
Fix for ZScore when the sdev is 0

### DIFF
--- a/src/main/scala/nak/cluster/Points.scala
+++ b/src/main/scala/nak/cluster/Points.scala
@@ -162,6 +162,7 @@ class ZscoreTransformer(
   def apply(points: IndexedSeq[Point]): IndexedSeq[Point] = {
     points.map { point =>
       val transformed = point.coord.zip(means.zip(standardDeviations)).map {
+        case (x, (mean, 0.0)) => 0.0
         case (x, (mean, sdev)) => (x - mean) / sdev
       }
       Point(transformed)


### PR DESCRIPTION
May happen, and an NaN freaks the ClusterConfusionMatrix out.
