### PR TITLE
The evaluation class is not generic

### DIFF
--- a/src/main/scala/nak/util/Evaluation.scala
+++ b/src/main/scala/nak/util/Evaluation.scala
@@ -114,7 +114,7 @@ object ConfusionMatrix {
 
   import scala.collection.mutable.ListBuffer
 
-  def apply[L,I](goldLabels: Seq[L], predictedLabels: Seq[Option[L]], items: Seq[I])(implicit ord: Ordering[L]) = {
+  def apply[L,I](goldLabels: Seq[L], predictedLabels: Seq[L], items: Seq[I])(implicit ord: Ordering[L]) = {
 
     val labels = (goldLabels.toSet ++ predictedLabels.toSet).toIndexedSeq.sorted
     val labelIndices = labels.zipWithIndex.toMap


### PR DESCRIPTION
I have just made the ConfusionMatrix generic on the type of label and examples. It's not yet clear to me what's the point of passing the examples in ;)
