### PR TITLE
split the result computation of ConfusionMatrix from the String display

### DIFF
--- a/src/main/scala/nak/util/Evaluation.scala
+++ b/src/main/scala/nak/util/Evaluation.scala
@@ -1,5 +1,7 @@
 package nak.util
 
+case class Scores(accuracy: Double, precisionAverage: Double, recallAverage: Double, fscoreAverage: Double, all: Seq[Seq[Double]] )
+
 /**
  * A confusion matrix for comparing gold clusters to some predicted clusters.
  *
@@ -20,8 +22,8 @@ class ConfusionMatrix(
 
   def formatPercent(percent: Double) = "%1.2f".format(100 * percent)
 
-  // Calculate accuracy, precision, recall, and F-score
-  lazy val measurements = {
+  lazy val scores = {
+    // Calculate accuracy, precision, recall, and F-score
     val goodCounts = counts.indices.map(index => counts(index)(index))
     val totalCounts = counts.map(_.sum).sum.toDouble
     val accuracy = goodCounts.sum / totalCounts
@@ -45,17 +47,20 @@ class ConfusionMatrix(
     val precisionAverage = precisionValues.sum / numLabels
     val recallAverage = recallValues.sum / numLabels
     val fscoreAverage = fscores.sum / numLabels
+    Scores(accuracy, precisionAverage, recallAverage, fscoreAverage, prfs)
+  }
 
+  lazy val measurements = {
     (lineSeparator
-      + "\t" * 2 + formatPercent(accuracy) + "\tOverall accuracy\n"
+      + "\t" * 2 + formatPercent(scores.accuracy) + "\tOverall accuracy\n"
       + lineSeparator + "P\tR\tF\n"
-      + prfs.zip(labels).map {
+      + scores.all.zip(labels).map {
         case (prf, label) => prf.map(formatPercent).mkString("\t") + "\t" + label
       }.mkString("\n")
-      + "\n" + "."*35 + "\n"
-      + formatPercent(precisionAverage) + "\t" 
-      + formatPercent(recallAverage) + "\t" 
-      + formatPercent(fscoreAverage) + "\tAverage")
+      + "\n" + "." * 35 + "\n"
+      + formatPercent(scores.precisionAverage) + "\t"
+      + formatPercent(scores.recallAverage) + "\t"
+      + formatPercent(scores.fscoreAverage) + "\tAverage")
   }
 
   lazy val detailedOutput = {


### PR DESCRIPTION
This makes the precision/recall/... measures available programmatically. Useful when you want to optimize a parameter on the training set and plot a graph, etc.
