### PR TITLE
make sure that we built the matrix with enough test examples

### DIFF
--- a/src/main/scala/nak/util/Evaluation.scala
+++ b/src/main/scala/nak/util/Evaluation.scala
@@ -78,7 +78,8 @@ class ConfusionMatrix(
 
   // Create a string representation. Be lazy so that we only do it once.
   lazy val stringRep = {
-    val lengthOfRow = counts(0).mkString.length + counts(0).length * 7
+    val lengthOfRow = if (counts.length > 0) counts(0).mkString.length + counts(0).length * 7
+    else 0
 
     val tableString =
       counts.zip(labels)
@@ -94,7 +95,7 @@ class ConfusionMatrix(
       tableString + "\n" +
       "-" * lengthOfRow + "\n" +
       counts.transpose.map(_.sum).mkString("\t") + "\n" +
-      labels.mkString(" ") + "\n"
+      labels.mkString("\t") + "\n"
       + "\n" + measurements)
   }
 


### PR DESCRIPTION
If we build a confusion matrix with an empty set of labels/examples, then the printout fails. This is a quickfix to avoid this. The results are not very meaningful though.

There is also a small change in the column separation for label names, that should be tabs and not spaces.
