### PR TITLE
there are cases where we cannot classify a test example

### DIFF
--- a/src/main/scala/nak/app/Classify.scala
+++ b/src/main/scala/nak/app/Classify.scala
@@ -60,9 +60,9 @@ object Classify {
 
       // Get the output distributions for the evaluation data.
       val comparisons = for (ex <- evalData) yield {
-	val scores = classifier.evalUnindexed(ex.features)
-	val best = scores.zipWithIndex.maxBy(_._1)._2
-	(ex.label, classifier.labelOfIndex(best))
+        val scores = classifier.evalUnindexed(ex.features)
+        val best = scores.map(p => classifier.labelOfIndex(p.zipWithIndex.maxBy(_._1)._2))
+        (ex.label, best)
       }
 
       // Compute and print out the confusion matrix.

--- a/src/main/scala/nak/util/Evaluation.scala
+++ b/src/main/scala/nak/util/Evaluation.scala
@@ -109,18 +109,19 @@ object ConfusionMatrix {
 
   import scala.collection.mutable.ListBuffer
 
-  def apply(goldLabels: Seq[String], predictedLabels: Seq[String], items: Seq[String]) = {
+  def apply(goldLabels: Seq[String], predictedLabels: Seq[Option[String]], items: Seq[String]) = {
 
-    val labels = (goldLabels.toSet ++ predictedLabels.toSet).toIndexedSeq.sorted
+    val labels = (goldLabels.toSet ++ predictedLabels.flatten.toSet).toIndexedSeq.sorted
     val labelIndices = labels.zipWithIndex.toMap
     val numLabels = labels.length
     val counts = Array.fill(numLabels, numLabels)(0)
     val examples = Array.fill(numLabels, numLabels)(new ListBuffer[String])
 
     goldLabels.zip(predictedLabels).zip(items).foreach {
-      case ((goldLabel, predLabel), item) =>
+      case ((goldLabel, Some(predLabel)), item) =>
         counts(labelIndices(goldLabel))(labelIndices(predLabel)) += 1
         examples(labelIndices(goldLabel))(labelIndices(predLabel)) += item
+      case _ => ;
     }
 
     new ConfusionMatrix(


### PR DESCRIPTION
When building features with a BOW/indexing approach, there might be a case where the example given to `classifier.predict` doesn't have any known features (e.g. a document with only words that have never been seen in the training set).

In such case, with scala, we can return an `Option` of the predicted label. If we can produce the prediction, we return `Some(label)`, if we can't make a prediction, we return `None`.
