### PR TITLE
Allow bidi-conversion NN.parameters <-> DenseVec

### DIFF
--- a/src/main/scala/nak/nnet/NeuralNetwork.scala
+++ b/src/main/scala/nak/nnet/NeuralNetwork.scala
@@ -74,6 +74,8 @@ class NNObjective[Output](data: IndexedSeq[(DenseVector[Double],Output)],
 
   def extract(x: DenseVector[Double]) = new NeuralNetwork(unrollWeights(x))
 
+  def pack(x : NeuralNetwork) = rollWeights(x.parameters)
+
   private val weightOffsets = {
     // just an unfold
     val arr = new Array[Int](layers.length)


### PR DESCRIPTION
Learning / minimizing works by taking a random input vector and training the random nn with a dataset.

However some applications may wish to take a trained NN as a starting point (e.g. if you know that the problem will change only slightly). This is currently impossible without duplicating the rollWeights logic.

It would be possible to work with the DenseVector, but that is a bit against the point of having a NN abstraction.

The new pack method takes the NN and packs it into a dense vector, making it possible to use a NN as an input to the minimize function.

Example:
nn is a trained NN.
obj is the basic objective.
import breeze.optimize._
val newNN = obj.extract(minimize(obj, obj.pack(nn)))
This will train a new NN taking the old nn as a starting point.

PS: it might make sense to call the methods pack/unpack, or s.th. similar that makes clear that both methods are bidirectional.
