### PR TITLE
bug fix

### DIFF
--- a/src/main/scala/nak/cluster/GDBSCAN.scala
+++ b/src/main/scala/nak/cluster/GDBSCAN.scala
@@ -67,7 +67,7 @@ class GDBSCAN[T](
           clustered add neighbour
         }
         // if the neighbour point is a cluster, join the neighbourhood
-        if (isCorePoint(neighbour, neighbourhood)) neighbourhood ++ newNeighbours else neighbourhood
+        if (isCorePoint(neighbour, newNeighbours)) neighbourhood ++ newNeighbours else neighbourhood
     }
 
   }


### PR DESCRIPTION
When join the neighborhood,  should query if current neighbor is a core point using its own size of neighbors compare with min size. 